### PR TITLE
Implement requiresMainQueueSetup

### DIFF
--- a/ios/ReactNativeIdfaAaid.swift
+++ b/ios/ReactNativeIdfaAaid.swift
@@ -4,6 +4,11 @@ import Foundation
 
 @objc(ReactNativeIdfaAaid)
 class ReactNativeIdfaAaid: NSObject {
+  
+    @objc
+    static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
 
     @objc(getAdvertisingInfo:withRejecter:)
     func getAdvertisingInfo(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {


### PR DESCRIPTION
Stops this warning

```
Module ReactNativeIdfaAaid requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```