### PR TITLE
build: use default minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
react native 0.70.12 requires a different minSdkVersion (21 and up). I suggest taking it from the getExtOrIntegerDefault method.
This is also done in other react native packages.