### PR TITLE
Fix: iOS 17.4 app tracking transparency bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 @sparkfabrik/react-native-idfa-aaid
+
 # React Native module to get IDFA (iOS) or AAID (Android)
 
 ## Intro
@@ -28,6 +29,7 @@ interface AdvertisingInfoResponse {
 ```sh
 npm install @sparkfabrik/react-native-idfa-aaid
 ```
+
 or
 
 ```sh
@@ -62,7 +64,6 @@ For `Expo` apps, in `app.json` make sure to add:
     ]
   }
 }
-
 ```
 
 ### React Native components
@@ -77,6 +78,28 @@ const MyComponent: React.FC = () => {
 
   useEffect(() => {
     ReactNativeIdfaAaid.getAdvertisingInfo()
+      .then((res: AdvertisingInfoResponse) =>
+        !res.isAdTrackingLimited ? setIdfa(res.id) : setIdfa(null),
+      )
+      .catch((err) => {
+        console.log(err);
+        return setIdfa(null);
+      });
+  }, []);
+```
+
+#### iOS 17.4
+
+In order to prevent a bug present in iOS 17.4 we also expose the `getAdvertisingInfoAndCheckAuthorization(check: boolean)` which aims to solve the problem of `ATT Tracking Manager` returning status `denied` even if the ATT modal was not yet displayed to the user.
+
+```js
+import ReactNativeIdfaAaid, { AdvertisingInfoResponse } from '@sparkfabrik/react-native-idfa-aaid';
+
+const MyComponent: React.FC = () => {
+  const [idfa, setIdfa] = useState<string | null>();
+
+  useEffect(() => {
+    ReactNativeIdfaAaid.getAdvertisingInfoAndCheckAuthorization(true)
       .then((res: AdvertisingInfoResponse) =>
         !res.isAdTrackingLimited ? setIdfa(res.id) : setIdfa(null),
       )

--- a/android/src/main/java/com/sparkfabrikreactnativeidfaaaid/ReactNativeIdfaAaidModule.kt
+++ b/android/src/main/java/com/sparkfabrikreactnativeidfaaaid/ReactNativeIdfaAaidModule.kt
@@ -30,4 +30,10 @@ class ReactNativeIdfaAaidModule(private val reactContext: ReactApplicationContex
         }
         promise.resolve(ret)
     }
+
+    @ReactMethod
+    fun getAdvertisingInfoAndCheckAuthorization(check: Boolean, promise: Promise): Unit {
+      // Check not needed on Android
+      getAdvertisingInfo(promise)
+    }
 }

--- a/ios/ReactNativeIdfaAaid.m
+++ b/ios/ReactNativeIdfaAaid.m
@@ -4,4 +4,8 @@
 
 RCT_EXTERN_METHOD(getAdvertisingInfo:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 
+/// Use this to enable an additional check and prevent a iOS 17.4 bug which causes the callback to be invoked immediately with a value of `status = denied`,
+/// even though the true value of `ATTrackingManager.trackingAuthorizationStatus`` is still `notDetermined` because the user has not yet made a choice by responding to the tracking consent popup.
+RCT_EXTERN_METHOD(getAdvertisingInfoAndCheckAuthorization:(BOOL)checkAuthorization withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/ReactNativeIdfaAaid.swift
+++ b/ios/ReactNativeIdfaAaid.swift
@@ -12,8 +12,15 @@ class ReactNativeIdfaAaid: NSObject {
 
     @objc(getAdvertisingInfo:withRejecter:)
     func getAdvertisingInfo(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+        getAdvertisingInfoAndCheckAuthorization(false, resolve: resolve, reject: reject)
+    }
+
+    /// Use this to enable an additional check and prevent a iOS 17.4 bug which causes the callback to be invoked immediately with a value of `status = denied`,
+    /// even though the true value of `ATTrackingManager.trackingAuthorizationStatus`` is still `notDetermined` because the user has not yet made a choice by responding to the tracking consent popup.
+    @objc(getAdvertisingInfoAndCheckAuthorization:withResolver:withRejecter:)
+    func getAdvertisingInfoAndCheckAuthorization(_ checkAuthorization: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         if #available(iOS 14, *) {
-            ATTrackingManager.requestTrackingAuthorization { status in
+            ATTrackingManager.requestTrackingAuthorization { [weak self] status in
                 switch status {
                     case .authorized:
                         // Tracking authorization dialog was shown
@@ -23,12 +30,17 @@ class ReactNativeIdfaAaid: NSObject {
                             "isAdTrackingLimited": false
                         ])
                     case .denied:
-                        // Tracking authorization dialog was
-                        // shown and permission is denied
-                        resolve([
-                            "id": nil,
-                            "isAdTrackingLimited": true
-                        ])
+                        if checkAuthorization, ATTrackingManager.trackingAuthorizationStatus == .notDetermined {
+                            // iOS 17.4 authorization bug detected
+                            self?.addObserver(resolve: resolve, reject: reject)
+                        } else {
+                            // Tracking authorization dialog was
+                            // shown and permission is denied
+                            resolve([
+                                "id": nil,
+                                "isAdTrackingLimited": true
+                            ])
+                        }
                     case .notDetermined:
                         // Tracking authorization dialog has not been shown
                         reject("@track_not_determined", "Tracking not determined", nil)
@@ -43,6 +55,26 @@ class ReactNativeIdfaAaid: NSObject {
                 "id": ASIdentifierManager.shared().advertisingIdentifier.uuidString,
                 "isAdTrackingLimited": false
             ])
+        }
+    }
+    
+    private weak var observer: NSObjectProtocol?
+    
+    private func addObserver(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        removeObserver()
+        
+        observer = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.getAdvertisingInfoAndCheckAuthorization(true, resolve: resolve, reject: reject)
+        }
+    }
+    
+    private func removeObserver() {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,9 @@ export type AdvertisingInfoResponse = {
 
 type ReactNativeIdfaAaidType = {
   getAdvertisingInfo(): Promise<AdvertisingInfoResponse>;
+  getAdvertisingInfoAndCheckAuthorization(
+    check: boolean
+  ): Promise<AdvertisingInfoResponse>;
 };
 
 const { ReactNativeIdfaAaid } = NativeModules;


### PR DESCRIPTION
Hi!

Due to a bug in iOS 17.4 `ATTrackingManager.requestTrackingAuthorization()` immediately triggers the callback with a value `status = denied`, even though the true value of `ATTrackingManager.trackingAuthorizationStatus` is still `notDetermined` because the user has not yet made a choice by responding to the tracking consent popup.

When this fix is enabled, the wrong status callback is not taken into account and the flow does not proceed until the user has responded to the popup: the app gets informed of the user choice through a `UIApplication.didBecomeActiveNotification` notification.

In order to be retrocompatible I made this fix disabled by default and I exposed another method: `getAdvertisingInfoAndCheckAuthorization()`

Please consider that I am a native developer and not a React dev. I opened this PR because this is the way we solved the problem on our company projects, for users who are using iOS 17.4 and beyond until the error is resolved by Apple. :) Feel free to use this PR as a guideline and to change the implemented logic and the names of functions/variables as you prefer.